### PR TITLE
#1106: thumbnail creation - pass QImage to QPixmap to avoid memory issues

### DIFF
--- a/python/tk_multi_breakdown/breakdown_list_item.py
+++ b/python/tk_multi_breakdown/breakdown_list_item.py
@@ -158,7 +158,7 @@ class BreakdownListItem(browser_widget.ListItem):
 
         # set thumbnail
         if data.get("thumbnail"):
-            self.ui.thumbnail.setPixmap(QtGui.QPixmap(data.get("thumbnail")))
+            self.ui.thumbnail.setPixmap(QtGui.QPixmap(QtGui.QImage(data.get("thumbnail"))))
 
         # set light - red or green
         if data["up_to_date"]:


### PR DESCRIPTION
Passing file path caches the qpixmap and creates issues: https://stackoverflow.com/questions/45846651/qpixmaps-in-pyqt-dont-get-cleaned-up-properly-when-made-directly-from-file-and